### PR TITLE
fixed #1 : Added checkbox to disable vector fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,20 @@
 <html lang="en">
 <head>
     <title>Planet</title>
+    <link rel="stylesheet" href="./style/checkbox-style.css">  
 </head>
 <body>
     
     <canvas id="field" style="position: absolute; z-index: 1;"></canvas>
     <canvas id="scribble" style="position: absolute;"></canvas>
+
+    <div class="checkbox-container">
+      <div class="checkbox-holder">
+        <label for="vector-check"><span>Hide Vectors:</span></label>
+        <input type="checkbox" id="vector-check">
+      </div>
+    </div>
+
     
     <script src="Planet.js"></script>
     <script src="Particle.js"></script>

--- a/script.js
+++ b/script.js
@@ -122,6 +122,24 @@ function drawDebugLines() {
 }
 
 
+
+/*
+  following is code which turns the vector visibility on and off
+  - on click of checkbox, it checks if checkbox is checked or not, then accordingly hides/shows the vectors
+*/
+let vectorCheckbox = document.querySelector('#vector-check');
+let canvasField = document.querySelector('#field');
+
+// checkbox click event listener
+vectorCheckbox.addEventListener('click', (ev) => {
+  if(vectorCheckbox.checked == true) {
+    canvasField.style.display = 'none';
+  }
+  else {
+    canvasField.style.display = 'block';    
+  }
+});
+
 // Initialize vector field once and only change on planet update
 for (vector of vectors) {
 	vector.update();

--- a/style/checkbox-style.css
+++ b/style/checkbox-style.css
@@ -1,0 +1,34 @@
+* {
+  margin : 0;
+
+}
+
+  @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap');
+
+.checkbox-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 5%;
+  height: 50px;
+  align-items: center;
+  margin-top: 1%;
+}
+.checkbox-holder {
+  z-index: 3;
+  background-color: rgba(87, 87, 87, 0.5);
+  border: 2px solid black;
+  font-weight: 600;
+  padding: 20px 40px 20px 40px;
+  font-size: 20px;
+  font-family: 'Poppins', sans-serif;
+}
+
+#vector-check {
+  width:25px;
+  height: 25px;
+
+  position: relative;
+  top:3px;
+  left: 5px;
+  
+}


### PR DESCRIPTION
fixed #1 
---

- A checkbox at the top right of the webpage to enable/disable vector fields.
- Google fonts used to style the checkbox label.
- The checkbox doesn't remove the vectors, it just applies `display:none;` to the field area. Therefore vectors are still being rendered in the background.
---

## Following attested images of the work -
---
![Screenshot_20230205_154756](https://user-images.githubusercontent.com/11803841/216813387-966c45de-928f-4bf4-902d-3be35126e7ad.png)
![Screenshot_20230205_154805](https://user-images.githubusercontent.com/11803841/216813391-863767ae-286f-4607-b8b9-b0cf298bd42a.png)
